### PR TITLE
Update log4j to 2.17.1 due to CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <packageVersion.dir>com/staffbase/plugins/sdk</packageVersion.dir>
         <packageVersion.package>${project.groupId}.json</packageVersion.package>
         <jose4j.version>0.7.9</jose4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>4.2.0</mockito.version>
     </properties>


### PR DESCRIPTION
We probably have a to do another release afterwards, although it's not a severe problem.