### PR TITLE
fix: Upgrade GitHub Actions to v4 to fix Node.js 20 deprecation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,12 +13,13 @@ jobs:
 
     steps:
     - name: Check out Git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install Java and Maven
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        java-version: '8'
+        distribution: 'temurin'
 
     - name: Release Maven package
       uses: samuelmeuli/action-maven-publish@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,16 @@ jobs:
     name: Java ${{ matrix.java }} Test
     strategy:
       matrix:
-        # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 8, 10, 11, 12, 13, 14]
+        # test against LTS versions supported by Temurin:
+        java: [ '8', '11', '17', '21' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
+        distribution: 'temurin'
 
     - name: Get latest release tag
       id: latest_release


### PR DESCRIPTION
## Summary
- Update actions/checkout from v2 to v4
- Update actions/setup-java from v1 to v4 with Temurin distribution
- Update Java matrix to LTS versions (8, 11, 17, 21)

The required runs are already updated in this PR https://github.com/Staffbase/infrastructure/pull/14333