### PR TITLE
Move plugins-sdk-java ownership to Central Tech (via CODEOWNERS)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,4 +12,3 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: need-for-speed


### PR DESCRIPTION
Moves `plugins-sdk-java` from `need-for-speed` to **Central Tech** (`product-central-tech`) as part of the post-restructuring Backstage org cleanup.

**Approach — CODEOWNERS as the leading source of truth.** `.github/CODEOWNERS` already reads `* @Staffbase/product-central-tech`; the only thing overriding it was the explicit `spec.owner: need-for-speed` in `catalog-info.yaml`. This PR **removes that line** so the catalog derives ownership from CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)